### PR TITLE
Make array literals consistent with hashes

### DIFF
--- a/Ruby.md
+++ b/Ruby.md
@@ -179,7 +179,7 @@ reason and you don’t do that too often.
 1. Write short arrays on one line like this:
 
    ```ruby
-   [1, 2, 3]
+   [ 1, 2, 3 ]
    ```
 
 1. Write longer arrays on multiple lines like this:


### PR DESCRIPTION
Having no spaces between brackets and values of array literals makes
the literals less readable and it also is inconsistent with the
formatting which is used for hashes.

To have a consistent way of formatting one-line literals we should
add spaces between square brackets and values.