### PR TITLE
Clarify usage of `raise` vs `fail`

### DIFF
--- a/Ruby.md
+++ b/Ruby.md
@@ -384,6 +384,9 @@ the code with return value checks. This power is easily misused.
    Rationale: Using `$!` is fragile. It easily breaks when exception is raised
    in an exception handler or code is moved around.
 
+1. Use `raise` for raising exceptions. While `fail` works as well it is not
+   very commonly used and should be avoided in order to prevent confusion.
+
 ##### Defining exception classes
 
 1. Make your exception classes subclasses of `StandardError` so they are

--- a/rubocop-suse.yml
+++ b/rubocop-suse.yml
@@ -64,3 +64,7 @@ Style/WordArray:
 Style/RegexpLiteral:
   StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#deviations-from-the-upstream-style-guide
   Enabled: false
+
+Style/SignalException:
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  EnforcedStyle: only_raise


### PR DESCRIPTION
This pull request makes it explicit that we prefer `raise` over `fail` for raising and re-raising exceptions (following the discussion in https://github.com/SUSE/style-guides/issues/9)