### PR TITLE
Disable Style/NumericLiterals by default

### DIFF
--- a/Ruby.md
+++ b/Ruby.md
@@ -585,3 +585,9 @@ quotes for better consistency.
 ### Style/StringLiteralsInInterpolation
 
 In interpolation double quotes are more practible, so prefer using them.
+
+### Style/NumericLiterals
+
+Rubocop's default value is to always check for underscores on large numeric
+literals. This is mostly fine, but it can be ridiculous, for example, if the
+application only uses "large" numeric literals for TCP ports.

--- a/rubocop-suse.yml
+++ b/rubocop-suse.yml
@@ -68,3 +68,7 @@ Style/RegexpLiteral:
 Style/SignalException:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
   EnforcedStyle: only_raise
+
+Style/NumericLiterals:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylenumericliterals
+  Enabled: false


### PR DESCRIPTION
I've also added the rationale for this in the Ruby.md file